### PR TITLE
Allow the header_editor_enabled config to be set from the initializer

### DIFF
--- a/lib/graphiql/rails/config.rb
+++ b/lib/graphiql/rails/config.rb
@@ -17,13 +17,14 @@ module GraphiQL
         "X-CSRF-Token" => -> (view_context) { view_context.form_authenticity_token }
       }
 
-      def initialize(query_params: false, initial_query: nil, title: nil, logo: nil, csrf: true, headers: DEFAULT_HEADERS)
+      def initialize(query_params: false, initial_query: nil, title: nil, logo: nil, csrf: true, headers: DEFAULT_HEADERS, header_editor_enabled: false)
         @query_params = query_params
         @headers = headers.dup
         @initial_query = initial_query
         @title = title
         @logo = logo
         @csrf = csrf
+        @header_editor_enabled = header_editor_enabled
       end
 
       # Call defined procs, add CSRF token if specified


### PR DESCRIPTION
Based on an open PR in [rmosolgo/graphiql-rails](https://github.com/rmosolgo/graphiql-rails/pull/96).

Quick fix so the header editor can be used per the gem's Readme.